### PR TITLE
perf: change base image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM public.ecr.aws/sam/build-python3.11:latest
+FROM amazon/aws-lambda-python:3.11
 
 RUN yum -y update && yum -y install zip
 
 COPY build-layer.sh /work/build-layer.sh
 
 WORKDIR /work
+
+# Override the entry point of the base image
+ENTRYPOINT [ "sh" ]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ PythonのLambda Layer用のzipを作成するdocker-compose.
 
     ```bash
     docker build . -t lambda-py-layer:latest
-    docker run -v .:/work --rm lambda-py-layer sh build-layer.sh
+    docker run -v .:/work --rm lambda-py-layer build-layer.sh
     ```
 
     `docker-compose`が使える場合は以下のコマンドでも良い。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,4 @@ services:
     volumes:
       - .:/work
     command: 
-      - sh
       - build-layer.sh


### PR DESCRIPTION
Before(`public.ecr.aws/sam/build-python3.11:latest`):
```
>docker images
REPOSITORY        TAG       IMAGE ID       CREATED          SIZE
lambda-py-layer   latest    b958f4cf7324   18 seconds ago   2.17GB
```

After(`amazon/aws-lambda-python:3.11`):
```
>docker images
REPOSITORY        TAG       IMAGE ID       CREATED          SIZE
lambda-py-layer   latest    d0d16a4f0bb9   12 minutes ago   1.07GB
```
